### PR TITLE
Prevent from displaying all attributes when only positive are present

### DIFF
--- a/autoxai/explainer/base_explainer.py
+++ b/autoxai/explainer/base_explainer.py
@@ -78,7 +78,7 @@ def determine_visualization_methods(
     else:
         log().info(msg="No negative attributes in the explained model.")
 
-    if np.any(attributions_np != 0):
+    if np.any(attributions_np < 0) and np.any(attributions_np > 0):
         explanation_methods.append(
             ExplanationMethods(
                 method=viz.ImageVisualizationMethod.heat_map,

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -41,7 +41,7 @@ class TestVisualizer:
         visualization_methods = determine_visualization_methods(
             attributions_np=ones_image.numpy()
         )
-        assert len(visualization_methods) == 3
+        assert len(visualization_methods) == 2
 
     def test_no_positive_values(self, minus_ones_image: torch.Tensor):
         _: matplotlib.pyplot.Figure = CVExplainer.visualize(
@@ -52,7 +52,7 @@ class TestVisualizer:
         visualization_methods = determine_visualization_methods(
             attributions_np=minus_ones_image.numpy()
         )
-        assert len(visualization_methods) == 3
+        assert len(visualization_methods) == 2
 
     def test_zeros_image(self, zeros_image: torch.Tensor):
         _: matplotlib.pyplot.Figure = CVExplainer.visualize(


### PR DESCRIPTION
## Description

Before when only positive attributes where present function `visualize` from `CVExplainer` class was displaying side by side: original image, positive attributes and the same attributes with label "All attributes". This PR prevents from displaying all attributes if only positive or only negative are present.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] `poetry run python example/mnist_wand.py` - with modified one of the explainers to `CV_NOISE_TUNNEL_EXPLAINER` (it gives only positive attributes) and check wandb page

## Checklist:

- [ ] I have updated all related `pyproject.toml` files.
- [ ] I have updated lock files.
- [x] I have set an Assignee and Reviewers.
- [x] I have labeled the PR correctly.
- [ ] I have performed a self-review of my own code.
- [ ] I have covered my code and changes with unit tests.
- [ ] I have annotated types as extensively as possible.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] All code references and dependencies will work.
