### PR TITLE
feat: GH Actions testing AutoXAI installation on different Python and CUDA versions

### DIFF
--- a/.github/workflows/installation_test.yaml
+++ b/.github/workflows/installation_test.yaml
@@ -9,8 +9,8 @@ jobs:
   autoxai:
     strategy:
       matrix:
-        CUDA_VERSION: ["10.2", "11.0", "11.4", "11.6"]
-        PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11"]
+        CUDA_VERSION: ["10.2"]  #  "11.0" , "11.4", "11.6"
+        PYTHON_VERSION: ["3.8"]  # "3.9", "3.10", "3.11"
     runs-on: gpu  # need to add `gpu` labels to self-hosted runners
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Added GH Actions for testing installation and running AutoXAI different Python and CUDA versions

Closing #31

### Defined Python Versions:
- 3.8
- 3.9
- 3.10
- 3.11
### Defined CUDA versions
- 10.2
- 11
- 11.4
- 11.6

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have updated all related `pyproject.toml` files.
- [ ] I have updated lock files.
- [ ] I have set an Assignee and Reviewers.
- [ ] I have labeled the PR correctly.
- [ ] I have performed a self-review of my own code.
- [ ] I have covered my code and changes with unit tests.
- [ ] I have annotated types as extensively as possible.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] All code references and dependencies will work.
